### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This project leverages Playwright for automated browser testing and integrates with Cloudflare Workers, [Browser Rendering](https://developers.cloudflare.com/browser-rendering/) and [`@cloudflare/playwright`](https://github.com/cloudflare/playwright) for deployment.
 
+<a href="https://glama.ai/mcp/servers/@cloudflare/playwright-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cloudflare/playwright-mcp/badge" alt="Cloudflare Playwright MCP server" />
+</a>
+
 ### Build and Deploy
 
 Follow these steps to set up and deploy the project:
@@ -35,7 +39,6 @@ You can now start to interact with the model, and it will run necessary tools to
 
 > [!TIP]
 > For best results, give simple instructions consisting of one single action, e. g., "Create a new todo entry", "Go to cloudflare site", "Take a screenshot"
-
 
 Example of a conversation:
 


### PR DESCRIPTION
This PR adds a badge for the [Cloudflare Playwright MCP](https://glama.ai/mcp/servers/@cloudflare/playwright-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@cloudflare/playwright-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cloudflare/playwright-mcp/badge" alt="Cloudflare Playwright MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.