### PR TITLE
Add missing `npm ci` before `npx wrangler deploy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npm run build
 
 ```bash
 cd cloudflare/example
+npm ci
 npx wrangler deploy
 ```
 


### PR DESCRIPTION
Otherwise this fails:

```console
src/index.ts:3:32 - error TS2307: Cannot find module '@cloudflare/playwright-mcp' or its corresponding type declarations.

3 import { createMcpAgent } from '@cloudflare/playwright-mcp';
```