### PR TITLE
fix: resolve Workers runtime compatibility issues for Cloudflare Browser Rendering

### DIFF
--- a/cloudflare/example/wrangler.toml
+++ b/cloudflare/example/wrangler.toml
@@ -1,6 +1,6 @@
 name = "playwright-mcp-example"
 main = "src/index.ts"
-compatibility_date = "2025-03-10"
+compatibility_date = "2025-09-23"
 compatibility_flags = ["nodejs_compat"]
 
 [browser]

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -13,6 +13,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
+    "postinstall": "patch-package",
     "build": "npm ci && npx vite build"
   },
   "exports": {
@@ -25,14 +26,15 @@
     }
   },
   "dependencies": {
-    "@cloudflare/playwright": "^0.0.11",
+    "@cloudflare/playwright": "1.1.2",
     "@modelcontextprotocol/sdk": "^1.17.0",
-    "agents": "^0.0.109",
+    "agents": "^0.4.0",
     "yaml": "^2.8.0",
     "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250725.0",
+    "patch-package": "^8.0.0",
     "vite": "^7.0.6"
   }
 }

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -30,7 +30,7 @@
     "@modelcontextprotocol/sdk": "^1.17.0",
     "agents": "^0.4.0",
     "yaml": "^2.8.0",
-    "zod-to-json-schema": "^3.24.6"
+    "zod-to-json-schema": "~3.24.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250725.0",

--- a/cloudflare/patches/@cloudflare+playwright+1.1.2.patch
+++ b/cloudflare/patches/@cloudflare+playwright+1.1.2.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/browserType.js b/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/browserType.js
+index 88a5d81..f754070 100644
+--- a/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/browserType.js
++++ b/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/browserType.js
+@@ -121,14 +121,16 @@ class BrowserType extends SdkObject {
+     } = options;
+     await this._createArtifactDirs(options);
+     const tempDirectories = [];
+-    const artifactsDir = await fs.promises.mkdtemp(path__default.join(os.tmpdir(), "playwright-artifacts-"));
++    const artifactsDir = path__default.join(os.tmpdir(), "playwright-artifacts-" + Math.random().toString(36).slice(2));
++    await fs.promises.mkdir(artifactsDir, { recursive: true });
+     tempDirectories.push(artifactsDir);
+     if (userDataDir) {
+       assert(path__default.isAbsolute(userDataDir), "userDataDir must be an absolute path");
+       if (!await existsAsync(userDataDir))
+         await fs.promises.mkdir(userDataDir, { recursive: true, mode: 448 });
+     } else {
+-      userDataDir = await fs.promises.mkdtemp(path__default.join(os.tmpdir(), `playwright_${this._name}dev_profile-`));
++      userDataDir = path__default.join(os.tmpdir(), `playwright_${this._name}dev_profile-` + Math.random().toString(36).slice(2));
++      await fs.promises.mkdir(userDataDir, { recursive: true });
+       tempDirectories.push(userDataDir);
+     }
+     await this.prepareUserDataDir(options, userDataDir);
+diff --git a/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/chromium/chromium.js b/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/chromium/chromium.js
+index ab3c9e9..86160e3 100644
+--- a/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/chromium/chromium.js
++++ b/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/chromium/chromium.js
+@@ -59,7 +59,8 @@ class Chromium extends BrowserType {
+       headersMap = { "User-Agent": getUserAgent() };
+     else if (headersMap && !Object.keys(headersMap).some((key) => key.toLowerCase() === "user-agent"))
+       headersMap["User-Agent"] = getUserAgent();
+-    const artifactsDir = await progress.race(fs.promises.mkdtemp(ARTIFACTS_FOLDER));
++    const artifactsDir = ARTIFACTS_FOLDER + Math.random().toString(36).slice(2);
++    await progress.race(fs.promises.mkdir(artifactsDir, { recursive: true }));
+     const doCleanup = async () => {
+       await removeFolders([artifactsDir]);
+       const cb = onClose;

--- a/cloudflare/vite.config.ts
+++ b/cloudflare/vite.config.ts
@@ -33,8 +33,7 @@ export default defineConfig({
 
       'playwright-core': '@cloudflare/playwright',
       'playwright': '@cloudflare/playwright/test',
-      'node:fs': '@cloudflare/playwright/fs',
-      'fs': '@cloudflare/playwright/fs',
+      'fs': 'node:fs',
 
       './package.js': path.resolve(__dirname, './src/package.ts'),
     },
@@ -100,7 +99,7 @@ export default defineConfig({
 
         '@cloudflare/playwright',
         '@cloudflare/playwright/test',
-        '@cloudflare/playwright/fs',
+        'node:fs',
         'cloudflare:workers',
 
         /@modelcontextprotocol\/sdk\/.*/,


### PR DESCRIPTION
## Summary

The Cloudflare example (`cloudflare/example/`) fails to deploy because of three interrelated runtime compatibility issues in the Workers environment. This PR fixes all three.

## Bug 1: `fs.mkdtemp` not available in Workers

**Root cause**: `vite.config.ts` aliases both `fs` and `node:fs` to `@cloudflare/playwright/fs`, but that shim does not implement `mkdtemp`. When `@cloudflare/playwright` calls `fs.promises.mkdtemp()` during browser launch, it crashes.

**Fix**: 
- Alias `fs` → `node:fs` instead of `@cloudflare/playwright/fs` (removes the `node:fs` alias too — only `fs` alias needed)
- Update externals to mark `node:fs` (not `@cloudflare/playwright/fs`)
- Patch `@cloudflare/playwright@1.1.2` to replace `mkdtemp` calls with `mkdir` + random suffix (3 locations in `browserType.js` and `chromium.js`)

## Bug 2: `compatibility_date` too old for `fs.mkdir`

**Root cause**: `wrangler.toml` has `compatibility_date = "2025-03-10"`, but `node:fs.mkdir` requires `>= 2025-09-23`.

**Fix**: Update `compatibility_date` to `2025-09-23`.

## Bug 3: Durable Object hibernation crash — "Already connected to a transport"

**Root cause**: When the `McpAgent` Durable Object hibernates and wakes up, `onStart()` calls `server.connect(transport)` but the MCP `Server` instance still thinks it's connected from before hibernation. It throws `"Already connected to a transport"`.

**Fix**: Upgrade `agents` from `^0.0.109` to `^0.4.0`. As identified in [cloudflare/agents#1239](https://github.com/cloudflare/agents/issues/1239), this was caused by a security issue (CVE-2026-25536 / GHSA-345p-7cg4-v4c7) in `@modelcontextprotocol/sdk < 1.26.0` — reusing server/transport instances can leak cross-client data. `agents@0.4.0+` includes `@modelcontextprotocol/sdk@1.26.0` which creates fresh Server/transport instances per connection, fixing both the crash and the security vulnerability.

> **Previous approach**: We initially patched `agents@0.0.109` with `server.close()` before `server.connect()`, but Sunil Pai ([@threepointone](https://github.com/threepointone)) from Cloudflare [pointed out](https://github.com/cloudflare/agents/issues/1239#issuecomment-3047990413) that this re-enables the vulnerable pattern the SDK was designed to prevent. The correct fix is the version upgrade.

## Changes

| File | Change |
|------|--------|
| `cloudflare/vite.config.ts` | `fs`/`node:fs` alias → `node:fs`; external `@cloudflare/playwright/fs` → `node:fs` |
| `cloudflare/example/wrangler.toml` | `compatibility_date` → `2025-09-23` |
| `cloudflare/package.json` | Pin `@cloudflare/playwright` to `1.1.2`, upgrade `agents` to `^0.4.0`, add `patch-package` |
| `cloudflare/patches/@cloudflare+playwright+1.1.2.patch` | `mkdtemp` → `mkdir` + random suffix |

## Testing

Deployed and verified on two separate Cloudflare accounts (free and paid Workers plans). All MCP tools (`browser_navigate`, `browser_snapshot`, `browser_take_screenshot`, `browser_close`) work correctly after these fixes. Tested with both `agents@0.4.0` (no patches) confirming the Durable Object hibernation issue is fully resolved.