### PR TITLE
feat: optional Bearer token auth, screenshot download, and SSE keepalive for CLI/TUI clients

### DIFF
--- a/cloudflare/example/src/index.ts
+++ b/cloudflare/example/src/index.ts
@@ -4,14 +4,291 @@ import { createMcpAgent } from '@cloudflare/playwright-mcp';
 
 export const PlaywrightMCP = createMcpAgent(env.BROWSER);
 
+// ---------------------------------------------------------------------------
+// Screenshot download store
+// ---------------------------------------------------------------------------
+// When MCP screenshot tools return base64 image data over SSE, the data is
+// extracted into this in-memory store and replaced with a download URL.
+// This allows clients that cannot handle inline images (CLI tools, TUI apps)
+// to download screenshots via a simple HTTP GET.
+const IMAGE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const imageStore = new Map<string, { data: string; mimeType: string; created: number }>();
+
+function cleanExpiredImages() {
+  const now = Date.now();
+  for (const [key, entry] of imageStore) {
+    if (now - entry.created > IMAGE_TTL_MS) {
+      imageStore.delete(key);
+    }
+  }
+}
+
+function generateHash(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+// ---------------------------------------------------------------------------
+// SSE stream interceptor with keepalive
+// ---------------------------------------------------------------------------
+// Wraps the SSE ReadableStream, parsing each event. When a JSON-RPC response
+// contains image content (from browser_take_screenshot), extracts the base64
+// data into imageStore and replaces it with a download URL.
+//
+// Also injects SSE keepalive comments (`: keepalive`) every 15 s to prevent
+// Cloudflare's proxy layer from dropping idle SSE connections (~60-90 s).
+// The returned `done` promise should be passed to `ctx.waitUntil()` so the
+// Worker execution context stays alive long enough for the timer to fire.
+// ---------------------------------------------------------------------------
+const SSE_KEEPALIVE_INTERVAL_MS = 15_000;
+
+function createImageInterceptingStream(
+  body: ReadableStream<Uint8Array>,
+  baseUrl: string,
+): { stream: ReadableStream<Uint8Array>; done: Promise<void> } {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const keepaliveBytes = encoder.encode(': keepalive\n\n');
+  let buffer = '';
+  let reader: ReadableStreamDefaultReader<Uint8Array>;
+  let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+  let cancelled = false;
+
+  let resolveDone: () => void;
+  const done = new Promise<void>((r) => { resolveDone = r; });
+
+  function cleanup() {
+    cancelled = true;
+    if (keepaliveTimer) { clearInterval(keepaliveTimer); keepaliveTimer = null; }
+    resolveDone();
+  }
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      reader = body.getReader();
+
+      // SSE comments (`:` prefix) are ignored by all compliant clients.
+      keepaliveTimer = setInterval(() => {
+        if (!cancelled) {
+          try {
+            controller.enqueue(keepaliveBytes);
+          } catch {
+            cleanup();
+          }
+        }
+      }, SSE_KEEPALIVE_INTERVAL_MS);
+
+      (async () => {
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+
+            let delimIdx: number;
+            while ((delimIdx = buffer.indexOf('\n\n')) !== -1) {
+              const rawEvent = buffer.slice(0, delimIdx + 2);
+              buffer = buffer.slice(delimIdx + 2);
+
+              const intercepted = interceptImageEvent(rawEvent, baseUrl);
+              controller.enqueue(encoder.encode(intercepted));
+            }
+          }
+
+          if (buffer.length > 0) {
+            controller.enqueue(encoder.encode(buffer));
+            buffer = '';
+          }
+          controller.close();
+        } catch (err) {
+          if (!cancelled) controller.error(err);
+        } finally {
+          cleanup();
+        }
+      })();
+    },
+
+    cancel() {
+      cleanup();
+      reader?.cancel().catch(() => {});
+    },
+  });
+
+  return { stream, done };
+}
+
+function interceptImageEvent(rawEvent: string, baseUrl: string): string {
+  if (!rawEvent.startsWith('event: message\n')) {
+    return rawEvent;
+  }
+
+  const dataPrefix = 'data: ';
+  const lines = rawEvent.split('\n');
+  const dataLineIdx = lines.findIndex(l => l.startsWith(dataPrefix));
+  if (dataLineIdx === -1) return rawEvent;
+
+  const jsonStr = lines[dataLineIdx].slice(dataPrefix.length);
+  let msg: any;
+  try {
+    msg = JSON.parse(jsonStr);
+  } catch {
+    return rawEvent;
+  }
+
+  // JSON-RPC responses with result.content containing image items
+  if (!msg?.result?.content || !Array.isArray(msg.result.content)) {
+    return rawEvent;
+  }
+
+  let modified = false;
+  const downloadUrls: string[] = [];
+
+  for (let i = 0; i < msg.result.content.length; i++) {
+    const item = msg.result.content[i];
+    if (item.type === 'image' && item.data && item.mimeType) {
+      cleanExpiredImages();
+      const hash = generateHash();
+      imageStore.set(hash, {
+        data: item.data,
+        mimeType: item.mimeType,
+        created: Date.now(),
+      });
+
+      const downloadUrl = `${baseUrl}/download/${hash}`;
+      downloadUrls.push(downloadUrl);
+
+      // Replace large base64 data with a download URL reference
+      msg.result.content[i] = {
+        type: 'text',
+        text: `[Screenshot captured - download: ${downloadUrl}]`,
+      };
+      modified = true;
+    }
+  }
+
+  if (modified && downloadUrls.length > 0) {
+    const urlList = downloadUrls.map((u, i) =>
+      downloadUrls.length === 1
+        ? `\n\nScreenshot download URL: ${u}`
+        : `\n\nScreenshot ${i + 1} download URL: ${u}`
+    ).join('');
+
+    for (let i = msg.result.content.length - 1; i >= 0; i--) {
+      if (msg.result.content[i].type === 'text' && !msg.result.content[i].text.startsWith('[Screenshot captured')) {
+        msg.result.content[i].text += urlList;
+        break;
+      }
+    }
+  }
+
+  if (!modified) return rawEvent;
+
+  lines[dataLineIdx] = dataPrefix + JSON.stringify(msg);
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Auth helpers
+// ---------------------------------------------------------------------------
+// Optional Bearer token authentication. Set the MCP_AUTH_TOKEN secret via
+// `wrangler secret put MCP_AUTH_TOKEN` to enable. If not set, all routes
+// are publicly accessible (matching the upstream default behavior).
+// ---------------------------------------------------------------------------
+function unauthorized() {
+  return new Response('Unauthorized', {
+    status: 401,
+    headers: { 'WWW-Authenticate': 'Bearer' },
+  });
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const bufA = enc.encode(a);
+  const bufB = enc.encode(b);
+  if (bufA.byteLength !== bufB.byteLength) return false;
+  return crypto.subtle.timingSafeEqual(bufA, bufB);
+}
+
+// ---------------------------------------------------------------------------
+// Worker fetch handler
+// ---------------------------------------------------------------------------
 export default {
-  fetch(request: Request, env: Env, ctx: ExecutionContext) {
-    const { pathname }  = new URL(request.url);
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    // Optional auth: if MCP_AUTH_TOKEN is configured, require Bearer token
+    if (env.MCP_AUTH_TOKEN) {
+      const authHeader = request.headers.get('Authorization') ?? '';
+      const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+      if (!token || !timingSafeEqual(token, env.MCP_AUTH_TOKEN)) {
+        return unauthorized();
+      }
+    }
+
+    const url = new URL(request.url);
+    const { pathname } = url;
+    const baseUrl = `${url.protocol}//${url.host}`;
+
+    // /download/<hash> — one-time download of a captured screenshot
+    if (pathname.startsWith('/download/')) {
+      const hash = pathname.slice('/download/'.length);
+      if (!hash) {
+        return new Response(JSON.stringify({ error: 'Missing hash' }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      cleanExpiredImages();
+      const entry = imageStore.get(hash);
+      if (!entry) {
+        return new Response(JSON.stringify({ error: 'Screenshot not found or expired' }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      // Decode base64 to binary
+      const binaryStr = atob(entry.data);
+      const bytes = new Uint8Array(binaryStr.length);
+      for (let i = 0; i < binaryStr.length; i++) {
+        bytes[i] = binaryStr.charCodeAt(i);
+      }
+
+      // One-time download: remove after serving
+      imageStore.delete(hash);
+
+      const ext = entry.mimeType === 'image/jpeg' ? 'jpg' : 'png';
+      return new Response(bytes, {
+        headers: {
+          'content-type': entry.mimeType,
+          'content-disposition': `attachment; filename="screenshot.${ext}"`,
+        },
+      });
+    }
 
     switch (pathname) {
       case '/sse':
-      case '/sse/message':
-        return PlaywrightMCP.serveSSE('/sse').fetch(request, env, ctx);
+      case '/sse/message': {
+        // Wrap the SSE stream to intercept screenshot images and make
+        // them downloadable via /download/<hash>
+        const sseResponse = await PlaywrightMCP.serveSSE('/sse').fetch(request, env, ctx);
+
+        // Only wrap GET /sse (the long-lived SSE stream), not POST /sse/message
+        if (request.method !== 'GET' || !sseResponse.body) return sseResponse;
+
+        const { stream: interceptedBody, done } = createImageInterceptingStream(sseResponse.body, baseUrl);
+
+        // Keep the Worker execution context alive so keepalive timers
+        // continue to fire for the lifetime of the SSE connection.
+        ctx.waitUntil(done);
+
+        return new Response(interceptedBody, {
+          status: sseResponse.status,
+          statusText: sseResponse.statusText,
+          headers: sseResponse.headers,
+        });
+      }
       case '/mcp':
         return PlaywrightMCP.serve('/mcp').fetch(request, env, ctx);
       default:

--- a/cloudflare/example/worker-configuration.d.ts
+++ b/cloudflare/example/worker-configuration.d.ts
@@ -5,6 +5,7 @@ declare namespace Cloudflare {
 	interface Env {
 		MCP_OBJECT: DurableObjectNamespace<import("./src/index").PlaywrightMCP>;
 		BROWSER: Fetcher;
+		MCP_AUTH_TOKEN?: string;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/cloudflare/example/wrangler.toml
+++ b/cloudflare/example/wrangler.toml
@@ -1,6 +1,6 @@
 name = "playwright-mcp-example"
 main = "src/index.ts"
-compatibility_date = "2025-03-10"
+compatibility_date = "2025-09-23"
 compatibility_flags = ["nodejs_compat"]
 
 [browser]

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -13,6 +13,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
+    "postinstall": "patch-package",
     "build": "npm ci && npx vite build"
   },
   "exports": {
@@ -25,14 +26,15 @@
     }
   },
   "dependencies": {
-    "@cloudflare/playwright": "^0.0.11",
+    "@cloudflare/playwright": "1.1.2",
     "@modelcontextprotocol/sdk": "^1.17.0",
-    "agents": "^0.0.109",
+    "agents": "^0.4.0",
     "yaml": "^2.8.0",
     "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250725.0",
+    "patch-package": "^8.0.0",
     "vite": "^7.0.6"
   }
 }

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -30,7 +30,7 @@
     "@modelcontextprotocol/sdk": "^1.17.0",
     "agents": "^0.4.0",
     "yaml": "^2.8.0",
-    "zod-to-json-schema": "^3.24.6"
+    "zod-to-json-schema": "~3.24.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250725.0",

--- a/cloudflare/patches/@cloudflare+playwright+1.1.2.patch
+++ b/cloudflare/patches/@cloudflare+playwright+1.1.2.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/browserType.js b/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/browserType.js
+index 88a5d81..f754070 100644
+--- a/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/browserType.js
++++ b/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/browserType.js
+@@ -121,14 +121,16 @@ class BrowserType extends SdkObject {
+     } = options;
+     await this._createArtifactDirs(options);
+     const tempDirectories = [];
+-    const artifactsDir = await fs.promises.mkdtemp(path__default.join(os.tmpdir(), "playwright-artifacts-"));
++    const artifactsDir = path__default.join(os.tmpdir(), "playwright-artifacts-" + Math.random().toString(36).slice(2));
++    await fs.promises.mkdir(artifactsDir, { recursive: true });
+     tempDirectories.push(artifactsDir);
+     if (userDataDir) {
+       assert(path__default.isAbsolute(userDataDir), "userDataDir must be an absolute path");
+       if (!await existsAsync(userDataDir))
+         await fs.promises.mkdir(userDataDir, { recursive: true, mode: 448 });
+     } else {
+-      userDataDir = await fs.promises.mkdtemp(path__default.join(os.tmpdir(), `playwright_${this._name}dev_profile-`));
++      userDataDir = path__default.join(os.tmpdir(), `playwright_${this._name}dev_profile-` + Math.random().toString(36).slice(2));
++      await fs.promises.mkdir(userDataDir, { recursive: true });
+       tempDirectories.push(userDataDir);
+     }
+     await this.prepareUserDataDir(options, userDataDir);
+diff --git a/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/chromium/chromium.js b/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/chromium/chromium.js
+index ab3c9e9..86160e3 100644
+--- a/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/chromium/chromium.js
++++ b/node_modules/@cloudflare/playwright/lib/playwright-core/src/server/chromium/chromium.js
+@@ -59,7 +59,8 @@ class Chromium extends BrowserType {
+       headersMap = { "User-Agent": getUserAgent() };
+     else if (headersMap && !Object.keys(headersMap).some((key) => key.toLowerCase() === "user-agent"))
+       headersMap["User-Agent"] = getUserAgent();
+-    const artifactsDir = await progress.race(fs.promises.mkdtemp(ARTIFACTS_FOLDER));
++    const artifactsDir = ARTIFACTS_FOLDER + Math.random().toString(36).slice(2);
++    await progress.race(fs.promises.mkdir(artifactsDir, { recursive: true }));
+     const doCleanup = async () => {
+       await removeFolders([artifactsDir]);
+       const cb = onClose;

--- a/cloudflare/vite.config.ts
+++ b/cloudflare/vite.config.ts
@@ -33,8 +33,7 @@ export default defineConfig({
 
       'playwright-core': '@cloudflare/playwright',
       'playwright': '@cloudflare/playwright/test',
-      'node:fs': '@cloudflare/playwright/fs',
-      'fs': '@cloudflare/playwright/fs',
+      'fs': 'node:fs',
 
       './package.js': path.resolve(__dirname, './src/package.ts'),
     },
@@ -100,7 +99,7 @@ export default defineConfig({
 
         '@cloudflare/playwright',
         '@cloudflare/playwright/test',
-        '@cloudflare/playwright/fs',
+        'node:fs',
         'cloudflare:workers',
 
         /@modelcontextprotocol\/sdk\/.*/,


### PR DESCRIPTION
## Summary

Adds three features to the Cloudflare example worker that improve security, usability, and connection reliability for non-browser MCP clients (CLI tools, terminal UIs like OpenCode, etc.).

> **Depends on**: #54 (Workers runtime compatibility fixes). This PR includes those commits as its base.

## Feature 1: Optional Bearer Token Authentication

Protects all routes with Bearer token auth when the `MCP_AUTH_TOKEN` secret is configured.

```bash
wrangler secret put MCP_AUTH_TOKEN
```

- Uses `crypto.subtle.timingSafeEqual` for constant-time comparison
- Returns 401 with `WWW-Authenticate: Bearer` header on failure
- **Backward compatible**: If `MCP_AUTH_TOKEN` is not set, all routes remain publicly accessible

## Feature 2: Screenshot Download via SSE Stream Interception

**Problem**: CLI and TUI MCP clients (terminal-based tools) cannot display inline base64 images returned by `browser_take_screenshot`. The image data is returned as `{ type: 'image', data: '<base64>', mimeType: 'image/...' }` in the JSON-RPC response, but terminal clients have no way to render it.

**Solution**: A ReadableStream wraps the SSE response stream and:

1. Detects JSON-RPC responses containing `type: 'image'` content
2. Extracts the base64 data into an in-memory store (5-minute TTL)
3. Replaces the image content with a text message containing a download URL
4. Exposes `/download/<hash>` for one-time authenticated file download

```
# AI agent takes a screenshot via MCP tools
# Instead of receiving opaque base64 data, the response contains:
[Screenshot captured - download: https://your-worker.workers.dev/download/abc123...]

# Download the image:
curl -H "Authorization: Bearer $TOKEN" \
  https://your-worker.workers.dev/download/abc123... -o screenshot.jpg
```

The download endpoint:
- Requires the same Bearer token (if auth is enabled)
- Serves the file once then deletes it (one-time download)
- Auto-detects JPEG vs PNG from the original MIME type
- Entries expire after 5 minutes if not downloaded

## Feature 3: SSE Keepalive

**Problem**: The legacy SSE transport (`/sse`) creates a long-lived HTTP connection. Cloudflare's proxy layer drops idle connections after ~60-90 seconds. When the MCP client sends a tool call after idle time, the POST succeeds (202 Accepted) but the SSE read stream is dead, so the response never arrives — resulting in a timeout.

**Solution**: Injects SSE comment frames (`: keepalive\n\n`) every 15 seconds into the SSE stream. SSE comments are ignored by all compliant clients per the spec.

- Uses `setInterval` for the keepalive timer
- Uses `ctx.waitUntil(done)` to keep the Worker execution context alive for the SSE session lifetime
- Timer is cleaned up when the stream closes or the client disconnects
- Only wraps the GET `/sse` stream (not POST `/sse/message`)

## Changes

| File | Change |
|------|--------|
| `cloudflare/example/src/index.ts` | Auth middleware, SSE interceptor with keepalive, `/download/<hash>` endpoint |
| `cloudflare/example/worker-configuration.d.ts` | Add optional `MCP_AUTH_TOKEN` to Env type |

## Testing

Deployed and tested on two Cloudflare accounts. Verified:
- Auth works: no token → 401, wrong token → 401, correct token → 200
- SSE stream interception correctly extracts images and injects download URLs
- `/download/<hash>` serves valid JPEG/PNG files (verified dimensions/format)
- One-time download: second request to same hash returns 404
- Expiry: entries older than 5 minutes are cleaned up
- Keepalive: SSE stream survives 90+ seconds of idle time without dropping
- Tool calls succeed after extended idle periods (verified with browser_navigate + browser_snapshot)