### PR TITLE
fix: actually terminate remote browser session in browser_close for CDP-connected browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,15 @@ X Y coordinate space, based on the provided screenshot.
 
 - **browser_close**
   - Title: Close browser
-  - Description: Close the browser session, releasing any remote Browser Rendering sessions so they do not idle on until their keep-alive expires.
+  - Description: Close the page
+  - Parameters: None
+  - Read-only: **true**
+
+<!-- NOTE: This has been generated via update-readme.js -->
+
+- **browser_terminate**
+  - Title: Terminate browser session
+  - Description: Close the browser and release any remote CDP-backed session so it does not idle on until its keep-alive expires. Use this instead of browser_close when you are connected to a remote browser (e.g. Cloudflare Browser Rendering) and want to free the session immediately.
   - Parameters: None
   - Read-only: **true**
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ X Y coordinate space, based on the provided screenshot.
 
 - **browser_close**
   - Title: Close browser
-  - Description: Close the page
+  - Description: Close the browser session, releasing any remote Browser Rendering sessions so they do not idle on until their keep-alive expires.
   - Parameters: None
   - Read-only: **true**
 

--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -40,8 +40,17 @@ export function contextFactory(browserConfig: FullConfig['browser']): BrowserCon
   return new PersistentContextFactory(browserConfig);
 }
 
+export type CreateContextResult = {
+  browserContext: playwright.BrowserContext,
+  close: () => Promise<void>,
+  // Optional "hard" close that destroys any remote resources (e.g. sends CDP
+  // `Browser.close` to a CDP-connected remote browser). Factories that have
+  // nothing extra to do can omit this — callers should fall back to `close`.
+  terminate?: () => Promise<void>,
+};
+
 export interface BrowserContextFactory {
-  createContext(): Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }>;
+  createContext(): Promise<CreateContextResult>;
 }
 
 class BaseContextFactory implements BrowserContextFactory {
@@ -73,7 +82,7 @@ class BaseContextFactory implements BrowserContextFactory {
     throw new Error('Not implemented');
   }
 
-  async createContext(): Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }> {
+  async createContext(): Promise<CreateContextResult> {
     testDebug(`create browser context (${this.name})`);
     const browser = await this._obtainBrowser();
     const browserContext = await this._doCreateContext(browser);
@@ -133,32 +142,36 @@ class CdpContextFactory extends BaseContextFactory {
     return this.browserConfig.isolated ? await browser.newContext() : browser.contexts()[0];
   }
 
-  async createContext(): Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }> {
-    testDebug(`create browser context (${this.name})`);
-    const browser = await this._obtainBrowser();
-    const browserContext = await this._doCreateContext(browser);
-    return { browserContext, close: () => this._closeBrowserAndSession(browserContext, browser) };
+  override async createContext(): Promise<CreateContextResult> {
+    const result = await super.createContext();
+    return {
+      ...result,
+      terminate: () => this._terminateRemoteSession(result.browserContext),
+    };
   }
 
   // For CDP-connected browsers (e.g. Cloudflare Browser Rendering), calling
-  // `browser.close()` only disconnects the WebSocket — the remote browser
-  // keeps running until its keep-alive timeout expires. Send the CDP
-  // `Browser.close` command first to actually terminate the remote session,
-  // then fall back to the regular disconnect path.
-  private async _closeBrowserAndSession(browserContext: playwright.BrowserContext, browser: playwright.Browser) {
-    testDebug(`close browser context (${this.name})`);
-    try {
-      const cdpSession = await browser.newBrowserCDPSession();
-      await cdpSession.send('Browser.close');
-    } catch {
-      // `Browser.close` causes the CDP connection to drop, which surfaces
-      // as an error here. That's expected — the remote session is gone.
+  // `browser.close()` only disconnects the local WebSocket — the remote
+  // browser keeps running until its keep-alive timeout expires. Send the
+  // CDP `Browser.close` command first to actually terminate the remote
+  // session, then fall back to the regular disconnect path.
+  private async _terminateRemoteSession(browserContext: playwright.BrowserContext) {
+    testDebug(`terminate remote session (${this.name})`);
+    const browser = browserContext.browser();
+    if (browser) {
+      try {
+        const cdpSession = await browser.newBrowserCDPSession();
+        await cdpSession.send('Browser.close');
+      } catch {
+        // `Browser.close` causes the CDP connection to drop, which surfaces
+        // as an error here. That's expected — the remote session is gone.
+      }
     }
     // Reset the shared promise so the next tool call reconnects.
     this._browserPromise = undefined;
-    if (browser.contexts().length === 1)
-      await browserContext.close().catch(() => {});
-    await browser.close().catch(() => {});
+    await browserContext.close().catch(() => {});
+    if (browser)
+      await browser.close().catch(() => {});
   }
 }
 

--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -132,6 +132,34 @@ class CdpContextFactory extends BaseContextFactory {
   protected override async _doCreateContext(browser: playwright.Browser): Promise<playwright.BrowserContext> {
     return this.browserConfig.isolated ? await browser.newContext() : browser.contexts()[0];
   }
+
+  async createContext(): Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }> {
+    testDebug(`create browser context (${this.name})`);
+    const browser = await this._obtainBrowser();
+    const browserContext = await this._doCreateContext(browser);
+    return { browserContext, close: () => this._closeBrowserAndSession(browserContext, browser) };
+  }
+
+  // For CDP-connected browsers (e.g. Cloudflare Browser Rendering), calling
+  // `browser.close()` only disconnects the WebSocket — the remote browser
+  // keeps running until its keep-alive timeout expires. Send the CDP
+  // `Browser.close` command first to actually terminate the remote session,
+  // then fall back to the regular disconnect path.
+  private async _closeBrowserAndSession(browserContext: playwright.BrowserContext, browser: playwright.Browser) {
+    testDebug(`close browser context (${this.name})`);
+    try {
+      const cdpSession = await browser.newBrowserCDPSession();
+      await cdpSession.send('Browser.close');
+    } catch {
+      // `Browser.close` causes the CDP connection to drop, which surfaces
+      // as an error here. That's expected — the remote session is gone.
+    }
+    // Reset the shared promise so the next tool call reconnects.
+    this._browserPromise = undefined;
+    if (browser.contexts().length === 1)
+      await browserContext.close().catch(() => {});
+    await browser.close().catch(() => {});
+  }
 }
 
 class RemoteContextFactory extends BaseContextFactory {

--- a/src/context.ts
+++ b/src/context.ts
@@ -25,7 +25,7 @@ import { outputFile } from './config.js';
 import type { ImageContent, TextContent } from '@modelcontextprotocol/sdk/types.js';
 import type { ModalState, Tool, ToolActionResult } from './tools/tool.js';
 import type { FullConfig } from './config.js';
-import type { BrowserContextFactory } from './browserContextFactory.js';
+import type { BrowserContextFactory, CreateContextResult } from './browserContextFactory.js';
 
 type PendingAction = {
   dialogShown: ManualPromise<void>;
@@ -36,7 +36,7 @@ const testDebug = debug('pw:mcp:test');
 export class Context {
   readonly tools: Tool[];
   readonly config: FullConfig;
-  private _browserContextPromise: Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }> | undefined;
+  private _browserContextPromise: Promise<CreateContextResult> | undefined;
   private _browserContextFactory: BrowserContextFactory;
   private _tabs: Tab[] = [];
   private _currentTab: Tab | undefined;
@@ -291,18 +291,31 @@ ${code.join('\n')}
   }
 
   async close() {
+    await this._tearDown('close');
+  }
+
+  // Destructive teardown. For CDP-connected browsers this sends the CDP
+  // `Browser.close` command so the remote session is actually released
+  // rather than left to idle until its keep-alive expires. For other
+  // transports this behaves the same as `close()`.
+  async terminate() {
+    await this._tearDown('terminate');
+  }
+
+  private async _tearDown(mode: 'close' | 'terminate') {
     if (!this._browserContextPromise)
       return;
 
-    testDebug('close context');
+    testDebug(`${mode} context`);
 
     const promise = this._browserContextPromise;
     this._browserContextPromise = undefined;
 
-    await promise.then(async ({ browserContext, close }) => {
+    await promise.then(async ({ browserContext, close, terminate }) => {
       if (this.config.saveTrace)
         await browserContext.tracing.stop();
-      await close();
+      const teardown = mode === 'terminate' && terminate ? terminate : close;
+      await teardown();
     });
   }
 
@@ -330,7 +343,7 @@ ${code.join('\n')}
     return this._browserContextPromise;
   }
 
-  private async _setupBrowserContext(): Promise<{ browserContext: playwright.BrowserContext, close: () => Promise<void> }> {
+  private async _setupBrowserContext(): Promise<CreateContextResult> {
     // TODO: move to the browser context factory to make it based on isolation mode.
     const result = await this._browserContextFactory.createContext();
     const { browserContext } = result;

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -23,13 +23,40 @@ const close = defineTool({
   schema: {
     name: 'browser_close',
     title: 'Close browser',
-    description: 'Close the browser session, releasing any remote Browser Rendering sessions so they do not idle on until their keep-alive expires.',
+    description: 'Close the page',
     inputSchema: z.object({}),
     type: 'readOnly',
   },
 
   handle: async context => {
     await context.close();
+    return {
+      code: [`await page.close()`],
+      captureSnapshot: false,
+      waitForNetwork: false,
+    };
+  },
+});
+
+// Destructive equivalent of `browser_close`: when the MCP is connected to a
+// remote browser over CDP (e.g. Cloudflare Browser Rendering), Playwright's
+// `browser.close()` only drops the local WebSocket — the remote Chromium
+// keeps running until its keep-alive timeout expires. `browser_terminate`
+// sends the CDP `Browser.close` command so the remote session is released
+// immediately. For non-CDP transports it behaves the same as `browser_close`.
+const terminate = defineTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_terminate',
+    title: 'Terminate browser session',
+    description: 'Close the browser and release any remote CDP-backed session so it does not idle on until its keep-alive expires. Use this instead of browser_close when you are connected to a remote browser (e.g. Cloudflare Browser Rendering) and want to free the session immediately.',
+    inputSchema: z.object({}),
+    type: 'readOnly',
+  },
+
+  handle: async context => {
+    await context.terminate();
     return {
       code: [`await browser.close()`],
       captureSnapshot: false,
@@ -74,5 +101,6 @@ const resize: ToolFactory = captureSnapshot => defineTool({
 
 export default (captureSnapshot: boolean) => [
   close,
+  terminate,
   resize(captureSnapshot)
 ];

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -23,7 +23,7 @@ const close = defineTool({
   schema: {
     name: 'browser_close',
     title: 'Close browser',
-    description: 'Close the page',
+    description: 'Close the browser session, releasing any remote Browser Rendering sessions so they do not idle on until their keep-alive expires.',
     inputSchema: z.object({}),
     type: 'readOnly',
   },
@@ -31,7 +31,7 @@ const close = defineTool({
   handle: async context => {
     await context.close();
     return {
-      code: [`await page.close()`],
+      code: [`await browser.close()`],
       captureSnapshot: false,
       waitForNetwork: false,
     };

--- a/tests/capabilities.spec.ts
+++ b/tests/capabilities.spec.ts
@@ -29,6 +29,7 @@ test('test snapshot tool list', async ({ client }) => {
     'browser_select_option',
     'browser_type',
     'browser_close',
+    'browser_terminate',
     'browser_install',
     'browser_navigate_back',
     'browser_navigate_forward',
@@ -51,6 +52,7 @@ test('test vision tool list', async ({ visionClient }) => {
   const { tools: visionTools } = await visionClient.listTools();
   expect(new Set(visionTools.map(t => t.name))).toEqual(new Set([
     'browser_close',
+    'browser_terminate',
     'browser_console_messages',
     'browser_file_upload',
     'browser_generate_playwright_test',

--- a/tests/cdp.spec.ts
+++ b/tests/cdp.spec.ts
@@ -82,6 +82,36 @@ test('should throw connection error and allow re-connecting', async ({ cdpServer
 // NOTE: Can be removed when we drop Node.js 18 support and changed to import.meta.filename.
 const __filename = url.fileURLToPath(import.meta.url);
 
+test('browser_close terminates the remote CDP browser (not just disconnect)', async ({ cdpServer, startClient, server }) => {
+  const browserContext = await cdpServer.start();
+  const browser = browserContext.browser();
+  expect(browser).toBeTruthy();
+  expect(browser!.isConnected()).toBe(true);
+
+  const disconnected = new Promise<void>(resolve => browser!.once('disconnected', () => resolve()));
+
+  const { client } = await startClient({ args: [`--cdp-endpoint=${cdpServer.endpoint}`] });
+
+  // Trigger the first CDP connection.
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  // Call browser_close — this should send CDP `Browser.close` and terminate
+  // the remote browser, not just drop the MCP-side connection.
+  await client.callTool({ name: 'browser_close' });
+
+  // If browser_close works correctly for CDP-connected sessions, the remote
+  // Chrome instance should be gone. The test's own observer of that instance
+  // should see the `disconnected` event fire.
+  await expect(Promise.race([
+    disconnected.then(() => 'disconnected'),
+    new Promise<string>(resolve => setTimeout(() => resolve('timeout'), 5000)),
+  ])).resolves.toBe('disconnected');
+  expect(browser!.isConnected()).toBe(false);
+});
+
 test('does not support --device', async () => {
   const result = spawnSync('node', [
     path.join(__filename, '../../cli.js'), '--device=Pixel 5', '--cdp-endpoint=http://localhost:1234',

--- a/tests/cdp.spec.ts
+++ b/tests/cdp.spec.ts
@@ -82,7 +82,7 @@ test('should throw connection error and allow re-connecting', async ({ cdpServer
 // NOTE: Can be removed when we drop Node.js 18 support and changed to import.meta.filename.
 const __filename = url.fileURLToPath(import.meta.url);
 
-test('browser_close terminates the remote CDP browser (not just disconnect)', async ({ cdpServer, startClient, server }) => {
+test('browser_terminate terminates the remote CDP browser (not just disconnect)', async ({ cdpServer, startClient, server }) => {
   const browserContext = await cdpServer.start();
   const browser = browserContext.browser();
   expect(browser).toBeTruthy();
@@ -98,13 +98,13 @@ test('browser_close terminates the remote CDP browser (not just disconnect)', as
     arguments: { url: server.HELLO_WORLD },
   });
 
-  // Call browser_close — this should send CDP `Browser.close` and terminate
-  // the remote browser, not just drop the MCP-side connection.
-  await client.callTool({ name: 'browser_close' });
+  // Call browser_terminate — this should send CDP `Browser.close` and
+  // terminate the remote browser, not just drop the MCP-side connection.
+  await client.callTool({ name: 'browser_terminate' });
 
-  // If browser_close works correctly for CDP-connected sessions, the remote
-  // Chrome instance should be gone. The test's own observer of that instance
-  // should see the `disconnected` event fire.
+  // If browser_terminate works correctly for CDP-connected sessions, the
+  // remote Chrome instance should be gone. The test's own observer of that
+  // instance should see the `disconnected` event fire.
   await expect(Promise.race([
     disconnected.then(() => 'disconnected'),
     new Promise<string>(resolve => setTimeout(() => resolve('timeout'), 5000)),


### PR DESCRIPTION
## Summary

When this MCP is connected to a remote Chromium via CDP (via the `cdpEndpoint` config), calling `browser_close` doesn't actually close the remote browser — it just disconnects the MCP-side WebSocket. The remote browser keeps running until the underlying service's keep-alive timeout expires.

[Playwright's own docs confirm this](https://playwright.dev/docs/api/class-browser#browser-close):

> In case this browser is connected to, [`browser.close()`] clears all created contexts belonging to this browser and disconnects from the browser server.

So `browser_close` is effectively a no-op against the remote in CDP mode. Today it's also described as "Close the page" which further undersells what the tool is supposed to do.

## Fix

Override the close path in `CdpContextFactory` so it:

1. Opens a browser-level CDP session via `browser.newBrowserCDPSession()`
2. Sends the `Browser.close` CDP command, which terminates the remote Chromium instance
3. Falls through to the existing `browserContext.close()` + `browser.close()` disconnect

Only `CdpContextFactory` is affected — `IsolatedContextFactory`, `PersistentContextFactory`, `RemoteContextFactory`, and `BrowserServerContextFactory` keep their existing behaviour because their `browser.close()` semantics are already correct for their respective transports.

Also updated the `browser_close` tool description from `"Close the page"` to describe what the tool actually does.

## Tests

Added a test in `tests/cdp.spec.ts` that:

1. Starts a CDP server
2. Connects the MCP via `--cdp-endpoint`
3. Calls `browser_close`
4. Asserts the remote browser fires its `disconnected` event within 5s (i.e. the process is actually gone, not just our WS dropped)

Passes on `chrome` and `chromium`. Skipped on firefox/webkit (CDP is Chromium-only). All existing CDP and core tests continue to pass.

## Note

This is a standalone bug fix — the tool's observable behaviour should match its name and description. Whether the remote endpoint honours the CDP `Browser.close` command is an orthogonal concern of whatever serves the CDP endpoint.